### PR TITLE
Added option to change checking interval + more suspend after intervals

### DIFF
--- a/background.js
+++ b/background.js
@@ -332,8 +332,10 @@ var tgs = (function () {
     }
 
     //start timer
-    setInterval(function () {
-        checkForTabsToAutoSuspend();
-    }, 1000 * 60);
+	function timerCheck(){
+		checkForTabsToAutoSuspend();
+		setTimeout(timerCheck, 1000 * gsStorage.fetchTimeToCheckOption());	
+	}
+    setTimeout(timerCheck, 1000 * gsStorage.fetchTimeToCheckOption());
 
 }());

--- a/gsStorage.js
+++ b/gsStorage.js
@@ -56,6 +56,16 @@
             localStorage.setItem("gsTimeToSuspend", timeToSuspend);
         },
 
+		fetchTimeToCheckOption : function () {
+            return localStorage.getItem("gsTimeToCheck") || 60;
+        },
+
+        setTimeToCheckOption : function (timeToSuspend) {
+            localStorage.setItem("gsTimeToCheck", timeToSuspend);
+        },
+
+
+
         fetchUnsuspendOnFocusOption : function () {
             return localStorage.getItem("gsUnsuspendOnFocus") ? localStorage.getItem("gsUnsuspendOnFocus") === "true" : false;
         },

--- a/options.html
+++ b/options.html
@@ -27,10 +27,17 @@
 	<br />
 	<br />
 
+	<label for="timeToCheck">Time between checking to close tabs</label>
+	<br />
+	<input id="timeToCheck" size="4" > seconds
+	<br />
 	<label id="timeToSuspendLbl" for="timeToSuspend">Length of inactivity before tab suspends automatically:</label>
 	<br />
 	<select id="timeToSuspend">
 		<option value="0">Never</option>
+		<option value="0.166">10 secs</option>
+		<option value="0.5">30 secs</option>
+		<option value="1">1 min</option>
 		<option value="5">5 mins</option>
 		<option value="15">15 mins</option>
 		<option value="30">30 mins</option>

--- a/options.js
+++ b/options.js
@@ -36,12 +36,18 @@
         var preview = gsStorage.fetchPreviewOption(),
             unsuspendOnFocus = gsStorage.fetchUnsuspendOnFocusOption(),
             timeToSuspend = gsStorage.fetchTimeToSuspendOption(),
+
+			timeToCheck = gsStorage.fetchTimeToCheckOption(),
+
             whitelist = gsStorage.fetchWhitelist();
 
         document.getElementById("preview").checked = preview;
         document.getElementById("unsuspendOnFocus").checked = unsuspendOnFocus;
         document.getElementById("whitelist").value = whitelist;
         selectComboBox(document.getElementById("timeToSuspend"), timeToSuspend);
+
+		document.getElementById("timeToCheck").value = timeToCheck;
+
     }
 
 
@@ -54,6 +60,9 @@
                 unsuspendOnFocusEl = document.getElementById("unsuspendOnFocus"),
                 whitelistEl = document.getElementById("whitelist"),
                 timeToSuspendEl = document.getElementById("timeToSuspend"),
+
+				timeToCheckEl = document.getElementById("timeToCheck"),
+
                 showHistoryEl = document.getElementById('showHistory'),
                 clearHistoryEl = document.getElementById('clearHistory');
 
@@ -69,6 +78,11 @@
             timeToSuspendEl.onchange = function (e) {
                 gsStorage.setTimeToSuspendOption(timeToSuspendEl.children[timeToSuspendEl.selectedIndex].value);
             };
+
+			timeToCheckEl.onchange = function (e) {
+			    gsStorage.setTimeToCheckOption(timeToCheckEl.value);
+			};
+
             showHistoryEl.onclick = function (e) {
                 chrome.tabs.create({url: chrome.extension.getURL("history.html")});
             };


### PR DESCRIPTION
A user can now change how often the extension checks to see how long pages have been inactive.
Also, the user can now suspend a page after 10 seconds inactivity.
