### PR TITLE
Batch features

### DIFF
--- a/background.js
+++ b/background.js
@@ -642,10 +642,12 @@ var tgs = (function () {
 
     chrome.commands.onCommand.addListener(function (command) {
         if (command === 'suspend-tab') {
-            chrome.tabs.query({active: true}, function (tabs) {
-                requestTabSuspension(tabs[0], true);
-            });
-        }
+		chrome.windows.getLastFocused({populate: true}, suspendHighlightedTab);
+        } else if (command === 'unsuspend-tab') {
+		chrome.windows.getLastFocused({populate: true}, unsuspendAllTabs);
+	} else if (command === 'suspend-others') {
+		chrome.windows.getLastFocused({populate: true}, suspendAllTabs);
+	}	
     });
 
     //careful. this seems to get called on extension reload as well as initial install

--- a/background.js
+++ b/background.js
@@ -184,8 +184,8 @@ var tgs = (function () {
 
     function suspendHighlightedTab(window) {
         chrome.tabs.query({windowId: window.id, highlighted: true}, function (tabs) {
-            if (tabs.length > 0) {
-                requestTabSuspension(tabs[0], true);
+            for (var i=0; i < tabs.length; i++) {
+                requestTabSuspension(tabs[i], true);
             }
         });
     }
@@ -200,8 +200,10 @@ var tgs = (function () {
 
     function suspendAllTabs(window) {
 
-        window.tabs.forEach(function (tab) {
-            requestTabSuspension(tab);
+        chrome.tabs.query({windowId: window.id, highlighted: false}, function (tabs) {
+            for (var i=0; i < tabs.length; i++) {
+                requestTabSuspension(tabs[i], false);
+            }
         });
     }
 

--- a/background.js
+++ b/background.js
@@ -200,9 +200,11 @@ var tgs = (function () {
 
     function suspendAllTabs(window) {
 
-        window.tabs.forEach(function (tab) {
-            requestTabSuspension(tab);
-        });
+	chrome.tabs.query( {highlighted:false}, function(tabs) {
+		for (var i=0; i < tabs.length; i++) {	
+			requestTabSuspension(tabs[i]);
+		}
+	});
     }
 
     function checkForSuspendedTab(tab, callback) {

--- a/background.js
+++ b/background.js
@@ -200,11 +200,9 @@ var tgs = (function () {
 
     function suspendAllTabs(window) {
 
-	chrome.tabs.query( {highlighted:false}, function(tabs) {
-		for (var i=0; i < tabs.length; i++) {	
-			requestTabSuspension(tabs[i]);
-		}
-	});
+        window.tabs.forEach(function (tab) {
+            requestTabSuspension(tab);
+        });
     }
 
     function checkForSuspendedTab(tab, callback) {

--- a/background.js
+++ b/background.js
@@ -84,9 +84,9 @@ var tgs = (function () {
     }
 
     function isExcluded(tab) {
-        if (tab.active) {
+        /*if (tab.active) {
             return true;
-        }
+        }*/
 
         //don't allow suspending of special tabs
         if (isSpecialTab(tab)) {
@@ -185,7 +185,7 @@ var tgs = (function () {
     function suspendHighlightedTab(window) {
         chrome.tabs.query({windowId: window.id, highlighted: true}, function (tabs) {
             for (var i=0; i < tabs.length; i++) {
-                requestTabSuspension(tabs[i], true);
+                requestTabSuspension(tabs[i], false);
             }
         });
     }

--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,6 @@
     "unsuspend-tab": {
       "description": "Unsuspend active tab",
       "suggested_key": { "default": "Ctrl+Shift+U" }
-    },
+    }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -39,12 +39,16 @@
 
   "commands": {
     "suspend-tab": {
-      "description": "Suspend active tab",
+      "description": "Suspend highlighted tabs",
       "suggested_key": { "default": "Ctrl+Shift+S" }
+    },
+    "suspend-others": {
+      "description": "Suspend non-highlighted tabs",
+      "suggested_key": { "default": "Ctrl+Shift+D" }
     },
     "unsuspend-tab": {
       "description": "Unsuspend active tab",
       "suggested_key": { "default": "Ctrl+Shift+U" }
-    }
+    },
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -19,11 +19,11 @@
 	<div id="middle">
 		<div class="menuOption" id="suspendOne" title="Suspend current tab">
 			<div class="icon iconSuspendCurrent"></div>
-			<div class="optionText">Suspend this tab</div>
+			<div class="optionText">Suspend highlighted tabs</div>
 		</div>
 		<div class="menuOption" id="suspendAll" title="Suspend all other tabs">
 			<div class="icon iconSuspendAll"></div>
-			<div class="optionText">Suspend other tabs</div>
+			<div class="optionText">Suspend non-highlighted tabs</div>
 		</div>
 		<div class="menuOption" href="#" id="unsuspendAll" title="Reload all tabs">
 			<div class="icon iconUnsuspendAll"></div>


### PR DESCRIPTION
I replaced "suspend this tab" with suspending all tabs that were highlighted, as well as with replacing "suspend other tabs" with suspending all other tabs that were not highlighted. This is useful because the user may want to batch suspend tabs or "protect" more than one tab from being suspended. I also added keyboard shorts for suspend non-highlighted, as well as fixed the keyboard shortcut for unsuspend all.