### PR TITLE
No html in session name

### DIFF
--- a/js/sessionUtils.js
+++ b/js/sessionUtils.js
@@ -340,12 +340,16 @@ var sessionUtils = (function () {
         return linksSpan;
     }
 
-    function createEl(elType, attributes, text) {
+    function createEl(elType, attributes, text, textOnly) {
 
         var el = document.createElement(elType);
         attributes = attributes || {};
         el = setElAttributes(el, attributes);
-        el.innerHTML = text || '';
+		if (textOnly) {
+			el.innerText = text || '';
+		} else {
+			el.innerHTML = text || '';
+		}
         return el;
     }
     function setElAttributes(el, attributes) {

--- a/js/sessionUtils.js
+++ b/js/sessionUtils.js
@@ -196,7 +196,7 @@ var sessionUtils = (function () {
 
         sessionTitle = createEl('span', {
             'class': 'sessionLink'
-        }, titleText);
+        }, titleText, true);
         sessionTitle.onclick = toggleSession(sessionDiv);
 
         if (!savedSession) {


### PR DESCRIPTION
Currently, the name of saved sessions are show in html. This may be a problem for inexperienced user (for exemple if they use name like ``<Categorie name> Name ``).

This correct this.