### PR TITLE
Fix screen capture preview quality setting

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -125,7 +125,7 @@ var tgs = (function () {
                     chrome.tabs.sendMessage(tab.id, {
                         action: 'generatePreview',
                         suspendedUrl: gsUtils.generateSuspendedUrl(tab.url, useClean),
-                        previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY)
+                        previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY) ? 0.8 : 0.1
                     });
                 });
 


### PR DESCRIPTION
I notice in the code that changing the code quality settings wasn't working properly.

[src/js/contentscript.js#L132-133](https://github.com/deanoemcke/thegreatsuspender/blob/master/src%2Fjs%2Fcontentscript.js#L132-133)
```javascript
var quality =  previewQuality || 0.1,
    dataUrl = canvas.toDataURL('image/jpeg', quality);
```

Checking/Unchecking "Use high quality screen captures" setting currently results in the following logic.

* Unchecked => previewQuality = false => quality = 0.1
* Checked => previewQuality = true => quality = true

In [src/js/background.js#L815](https://github.com/deanoemcke/thegreatsuspender/commit/96bea39ef8e9b2a58326c36edb036382a0fb1292#diff-f9b12bd72f40c9b8ed144484f0f12a5fR338), previewQuality is set to 0.8 or 0.1 based on an expected true/false flag. 

```javascript
previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY) ? 0.8 : 0.1
```

However, this same logic is missing in [src/js/background.js#L128](https://github.com/deanoemcke/thegreatsuspender/commit/fb1545eae87196f459334cc0c67afd42e880c3ea?diff=split#diff-2650fb3e14b7f42d68a8766269c54434R125), previewQuality is set to 0.8 or 0.1 based on an expected true/false flag. 

```javascript
previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY)
```

As a result, since true is passed instead of 0.8, the default image compression setting is used which according to this [webkit bug report](https://bugs.webkit.org/attachment.cgi?id=74360&action=review) is 0.92.  While a higher quality setting than 0.1, I don't believe it's working as expected.  This fix resolves the issue.