### PR TITLE
Fix for #233 of using less memory for screen captures

### DIFF
--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -104,10 +104,14 @@ a {
     width: 100%;
     height: 100%;
     background: #fff;
+    text-align: center;
 }
 #gsPreviewImg {
     width: 100%;
     margin-top:86px;
+}
+#gsPreviewImg.thumbnail {
+    width: auto!important;
 }
 .centerBoxContainer {
     text-align: center;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -125,7 +125,8 @@ var tgs = (function () {
                     chrome.tabs.sendMessage(tab.id, {
                         action: 'generatePreview',
                         suspendedUrl: gsUtils.generateSuspendedUrl(tab.url, useClean),
-                        previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY)
+                        previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY) ? 0.8 : 0.1,
+                        previewThumbnail: gsUtils.getOption(gsUtils.PREVIEW_THUMBNAIL)
                     });
                 });
 
@@ -812,7 +813,8 @@ var tgs = (function () {
                 dontSuspendForms: gsUtils.getOption(gsUtils.IGNORE_FORMS),
                 showPreview: gsUtils.getOption(gsUtils.SHOW_PREVIEW),
                 suspendTime: gsUtils.getOption(gsUtils.SUSPEND_TIME),
-                previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY) ? 0.8 : 0.1
+                previewQuality: gsUtils.getOption(gsUtils.PREVIEW_QUALITY) ? 0.8 : 0.1,
+                previewThumbnail: gsUtils.getOption(gsUtils.PREVIEW_THUMBNAIL)
             });
             break;
 

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -7,6 +7,7 @@
 
         SHOW_PREVIEW: 'preview',
         PREVIEW_QUALITY: 'previewQuality',
+        PREVIEW_THUMBNAIL: 'previewThumbnail',
         ONLINE_CHECK: 'onlineCheck',
         BATTERY_CHECK: 'batteryCheck',
         UNSUSPEND_ON_FOCUS: 'gsUnsuspendOnFocus',

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -15,6 +15,7 @@
         elementPrefMap = {
             'preview': gsUtils.SHOW_PREVIEW,
             'previewQuality': gsUtils.PREVIEW_QUALITY,
+            'previewThumbnail': gsUtils.PREVIEW_THUMBNAIL,
             'onlineCheck': gsUtils.ONLINE_CHECK,
             'batteryCheck': gsUtils.BATTERY_CHECK,
             'unsuspendOnFocus': gsUtils.UNSUSPEND_ON_FOCUS,
@@ -102,9 +103,11 @@
     function setPreviewQualityVisibility(visible) {
         if (visible) {
             document.getElementById('previewQualitySection').style.display = 'block';
+            document.getElementById('previewThumbnailSection').style.display = 'block';
             document.getElementById('previewQualityNote').style.display = 'block';
         } else {
             document.getElementById('previewQualitySection').style.display = 'none';
+            document.getElementById('previewThumbnailSection').style.display = 'none';
             document.getElementById('previewQualityNote').style.display = 'none';
         }
     }

--- a/src/js/suspended.js
+++ b/src/js/suspended.js
@@ -38,6 +38,7 @@
             tabProperties,
             rootUrlStr = gsUtils.getRootUrl(url),
             showPreview = gsUtils.getOption(gsUtils.SHOW_PREVIEW),
+            previewThubmnail = gsUtils.getOption(gsUtils.PREVIEW_THUMBNAIL),
             favicon,
             title,
             bodyEl = document.getElementsByTagName('body')[0],
@@ -67,6 +68,9 @@
                         bodyEl.appendChild(previewEl);
 
                         document.getElementById('gsPreviewImg').setAttribute('src', previewUrl);
+                        if (previewThubmnail) {
+                            document.getElementById('gsPreviewImg').setAttribute('class', 'thumbnail');
+                        }
 
                         messageEl.style.display = 'none';
                         previewEl.style.display = 'block';

--- a/src/options.html
+++ b/src/options.html
@@ -96,6 +96,14 @@
 			</label>
 		</div>
 
+		<div id="previewThumbnailSection" class="formRow">
+			<input type="checkbox" id="previewThumbnail" class='option' />
+			<label for="previewThumbnail" class="cbLabel">
+				Use thumbnails size (instead of full screen)<br />
+				<span class="lesserText">Uses less memory than default screen capture</span>
+			</label>
+		</div>
+
 		<div id="previewQualitySection" class="formRow">
 			<input type="checkbox" id="previewQuality" class='option' />
 			<label for="previewQuality" class="cbLabel">


### PR DESCRIPTION
I added some optimizations for decreasing memory while using screen capture option (#233).

WebP:
===============
Use WebP format instead of jpeg format for better quality images and 25%+ smaller (see https://developers.google.com/speed/webp/).

Thumbnails:
===============
Added option to capture as thumbnails instead of full screen using options panel.

RESULTS
===============

URL: http://www.cnn.com/
Dimensions: 1795 × 830

Default Quality (0.1)
---------------
* 47.6 KB - image/jpeg (before)
* 28.4 KB - image/webp
* 5.9 KB - image/webp as thumbnail


High Quality
---------------
* 167.0 KB - image/jpeg (before)
* 67.2 KB - image/webp
* 12.6 KB - image/webp as thumbnail


