### PR TITLE
Suspend/Unsuspend a group of selected tabs

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -38,7 +38,7 @@ a {
 .group {
 	padding: 5px 0;
 }
-.optsCurrent, .optsAll {
+.optsCurrent, .optsAll .optsSelected{
 	border-bottom: 1px solid #ccc;
 }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -242,9 +242,26 @@ var tgs = (function () {
 
         chrome.windows.getLastFocused({populate: true}, function(curWindow) {
             curWindow.tabs.forEach(function (currentTab) {
-
                 if (isSuspended(currentTab)) {
                     unsuspendTab(currentTab);
+                }
+            });
+        });
+    }
+
+    function suspendSelectedTabs() {
+        chrome.tabs.query({highlighted: true, lastFocusedWindow: true}, function (selectedTabs) {
+            selectedTabs.forEach(function (tab) {
+                requestTabSuspension(tab, true);
+            });
+        });
+    }
+
+    function unsuspendSelectedTabs() {
+        chrome.tabs.query({highlighted: true, lastFocusedWindow: true}, function (selectedTabs) {
+            selectedTabs.forEach(function (tab) {
+                if (isSuspended(tab)) {
+                    unsuspendTab(tab);
                 }
             });
         });
@@ -875,6 +892,14 @@ var tgs = (function () {
 
         case 'unsuspendAll':
             unsuspendAllTabs();
+            break;
+
+        case 'suspendSelected':
+            suspendSelectedTabs();
+            break;
+
+        case 'unsuspendSelected':
+            unsuspendSelectedTabs();
             break;
 
         default:

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -130,12 +130,12 @@
             var status = info.status,
                 //timeLeft = info.timerUp, // unused
                 suspendOneVisible = (status === 'suspended' || status === 'special' || status === 'unknown') ? false : true,
-                whitelistVisibe = (status !== 'whitelisted' && status !== 'special') ? true : false,
-                pauseVisibe = (status === 'normal') ? true : false;
+                whitelistVisible = (status !== 'whitelisted' && status !== 'special') ? true : false,
+                pauseVisible = (status === 'normal') ? true : false;
 
             setSuspendOneVisibility(suspendOneVisible);
-            setWhitelistVisibility(whitelistVisibe);
-            setPauseVisibility(pauseVisibe);
+            setWhitelistVisibility(whitelistVisible);
+            setPauseVisibility(pauseVisible);
             setStatus(status);
         });
     });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -95,6 +95,18 @@
         }
     }
 
+    function setSuspendSelectedVisibility() {
+        chrome.tabs.query({highlighted: true, lastFocusedWindow: true}, function (tabs) {
+            if (tabs && tabs.length > 1) {
+                document.getElementById('suspendSelected').style.display = 'block';
+                document.getElementById('unsuspendSelected').style.display = 'block';
+            } else {
+                document.getElementById('suspendSelected').style.display = 'none';
+                document.getElementById('unsuspendSelected').style.display = 'none';
+            }
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('suspendOne').addEventListener('click', function (e) {
             chrome.runtime.sendMessage({ action: 'suspendOne' });
@@ -106,6 +118,14 @@
         });
         document.getElementById('unsuspendAll').addEventListener('click', function (e) {
             chrome.runtime.sendMessage({ action: 'unsuspendAll' });
+            window.close();
+        });
+        document.getElementById('suspendSelected').addEventListener('click', function (e) {
+            chrome.runtime.sendMessage({ action: 'suspendSelected' });
+            window.close();
+        });
+        document.getElementById('unsuspendSelected').addEventListener('click', function (e) {
+            chrome.runtime.sendMessage({ action: 'unsuspendSelected' });
             window.close();
         });
         document.getElementById('whitelist').addEventListener('click', function (e) {
@@ -133,6 +153,7 @@
                 whitelistVisible = (status !== 'whitelisted' && status !== 'special') ? true : false,
                 pauseVisible = (status === 'normal') ? true : false;
 
+            setSuspendSelectedVisibility();
             setSuspendOneVisibility(suspendOneVisible);
             setWhitelistVisibility(whitelistVisible);
             setPauseVisibility(pauseVisible);

--- a/src/popup.html
+++ b/src/popup.html
@@ -33,6 +33,15 @@
 		</div>
 	</div>
 
+	<div class="group optsSelected">
+		<div class="menuOption" id="suspendSelected">
+			<i class="fa fa-stop"></i> <span class="optionText">Suspend selected tabs</span>
+		</div>
+		<div class="menuOption" href="#" id="unsuspendSelected">
+			<i class="fa fa-play"></i> <span class="optionText">Unsuspend selected tabs</span>
+		</div>
+	</div>
+
 	<div class="group optsSettings">
 		<div class="menuOption" id="settingsLink">
 			<i class="fa fa-wrench"></i> <span class="optionText">Settings</span>


### PR DESCRIPTION
This feature will allow a user to perform actions on a group of tabs selected using the Command or Control keys.  When multiple tabs are selected new options will surface in the popup menu to Suspend or Unsuspend the group of tabs.

I found myself trying to do this earlier today and was surprised it hadn't been implemented.  If you are not a tab selector, you will be none the wiser to this new feature.  If you do select tabs (like me), you will be pleasantly surprised with the new functionality.