### PR TITLE
factored out message handler and attached to both chrome.runtime.onMe…

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -800,7 +800,7 @@ var tgs = (function () {
 
     //HANDLERS FOR MESSAGE REQUESTS
 
-    chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+    var messageRequestListener = function (request, sender, sendResponse) {
         if (debug) {
             console.log('listener fired:', request.action);
             console.dir(sender);
@@ -880,7 +880,13 @@ var tgs = (function () {
         default:
             break;
         }
-    });
+    };
+
+    // attach listener to runtime
+    chrome.runtime.onMessage.addListener(messageRequestListener);
+    // attach listener to runtime for external messages, to allow 
+    // interoperability with other extensions in the manner of an API
+    chrome.runtime.onMessageExternal.addListener(messageRequestListener);
 
     // listen for focus changes
     chrome.windows.onFocusChanged.addListener(function (windowId) {


### PR DESCRIPTION
This was spawned after discussion with a contributor in [issue 276](https://github.com/deanoemcke/thegreatsuspender/issues/276).

The general idea is that attaching a message handler on chrome.runtime.onMessage only allows intra-extension scripts to send messages, while chrome.runtime.onMessageExternal responds to messages from other extensions, which can use the great suspender's extension ID to send messages, for example requesting a certain tab to be suspended programmatically.

This pull request exposes the full set of messages to external use, and while it would be trivial to restrict a subset for external exposure, I suspect this will be unnecessary caution barring some kind of abuse by another extension, in which case the user would want to uninstall that extension, and the offending malicious extension would also have a grounds for being reported to the chrome web store.