### PR TITLE
Display full URL on the tab suspended page. Fixes #309

### DIFF
--- a/src/js/suspended.js
+++ b/src/js/suspended.js
@@ -44,6 +44,7 @@ chrome.tabs.getCurrent(function(tab) {
             messageEl = document.getElementById('suspendedMsg'),
             titleEl = document.getElementById('gsTitle'),
             topBarEl = document.getElementById('gsTopBarTitle'),
+            topBarURLEl = document.getElementById('gsTopBarURL'),
             whitelistEl = document.getElementById('gsWhitelistLink'),
             linkedUrlEl = document.getElementById('gsLinkedUrl'),
             topBarImgEl = document.getElementById('gsTopBarImg');
@@ -99,6 +100,8 @@ chrome.tabs.getCurrent(function(tab) {
             titleEl.innerHTML = title;
             topBarEl.innerHTML = title;
             topBarEl.setAttribute('href', url);
+            topBarURLEl.innerHTML = url;
+            topBarURLEl.setAttribute('href', url);
             topBarImgEl.setAttribute('src', favicon);
 
             if (tabProperties.fakeTab && tabProperties.url) {

--- a/src/suspended.html
+++ b/src/suspended.html
@@ -10,7 +10,7 @@
 
 <div id="gsTopBar">
 	<div id="gsTitleWrap">
-		<img id='gsTopBarImg' /> <a id='gsTopBarTitle'></a>
+		<img id='gsTopBarImg' /> <a id='gsTopBarTitle'></a> (<a id='gsTopBarURL'></a>)
 	</div>
 	<a id='gsWhitelistLink'></a>
 	<a id='gsLinkedUrl'></a>


### PR DESCRIPTION
Quick and dirty way to fix #309. Just adds the URL in parentheses next to the page title.
It probably could use some better styling so I separated it into its own element.
