### PR TITLE
Fix sites with 'tainted canvas' error.

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -144,7 +144,11 @@
                     if (processing) {
                         processing = false;
                         timer = (new Date() - timer) / 1000;
-                        var dataUrl = canvas.toDataURL('image/webp', 0.8);
+                        try {
+                            var dataUrl = canvas.toDataURL('image/webp', 0.8);
+                        } catch(err) {
+                            var dataUrl = false;
+                        }
                         chrome.runtime.sendMessage({
                             action: 'savePreviewData',
                             previewUrl: dataUrl,


### PR DESCRIPTION
Some pages like wired.com won't suspend (either automatically or clicking to suspend) and throws an error... "Uncaught SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported." Not sure if there's a better way, but figured I'd throw this out if it helps anyone else as it's helping me.
