### PR TITLE
Hide top bar when UNSUSPEND_ON_FOCUS is enabled

### DIFF
--- a/src/js/suspended.js
+++ b/src/js/suspended.js
@@ -74,6 +74,13 @@ chrome.tabs.getCurrent(function(tab) {
 
                         messageEl.style.display = 'none';
                         previewEl.style.display = 'block';
+
+                        // Hide the top bar when tabs are unsuspended on focus
+                        var unsuspendOnFocus = gsUtils.getOption(gsUtils.UNSUSPEND_ON_FOCUS);
+                        if (unsuspendOnFocus) {
+                          document.getElementById('gsTopBar').style.display = 'none';
+                          document.getElementById('gsPreviewImg').style['margin-top'] = 0;
+                        }
                     }
                 });
 


### PR DESCRIPTION
The preview was not properly aligned with the page because of the top bar.
It gave the impression of a visual glitch when the tab was automatically
unsuspended.

This is fixed by collapsing the gsTopBar element (display=none) and
by clearing the top margin of the gsPreviewImg element.

When UNSUSPEND_ON_FOCUS is disabled, the top bar has to stay to give
a visual feedback to the user.
