### PR TITLE
deleted overflow on body

### DIFF
--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -42,8 +42,6 @@ body {
     position: absolute;
     height: 100%;
     width: 100%;
-    overflow-x:hidden;
-    overflow-y:hidden;
 }
 a {
     color: #3889AB;


### PR DESCRIPTION
If I delete in DevTools "overflow" from body, I can see and scroll image.
