### PR TITLE
Do not stretch previews

### DIFF
--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -117,8 +117,9 @@ a {
     background: #fff;
 }
 #gsPreviewImg {
-    width: 100%;
-    margin-top:86px;
+    display: block
+    max-width: 100%;
+    margin: 86px auto 0;
 }
 .centerBoxContainer {
     text-align: center;


### PR DESCRIPTION
Screenshots taken with narrow viewport and shown in wider one were stretched.

This change shows smaller previews centered, in their natural size, while keeping bigger previews contained in 100%.
