### PR TITLE
Don't suspend pinned when "suspend all" is pressed

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -158,6 +158,10 @@ var tgs = (function () {
 
         //otherwise perform soft checks before suspending
         } else {
+	    // check if we want to ignore pinned tabs
+	    if (!force && gsUtils.getOption(gsUtils.IGNORE_PINNED && isPinnedTab(tab)) {
+		return;
+	    }
 
             //check whitelist
             if (isExcluded(tab)) {
@@ -269,7 +273,7 @@ var tgs = (function () {
             chrome.windows.get(curWindowId, {populate: true}, function(curWindow) {
                 curWindow.tabs.forEach(function (tab) {
                     if (!tab.active) {
-                        requestTabSuspension(tab, true);
+                        requestTabSuspension(tab, false);
                     }
                 });
             });


### PR DESCRIPTION
Perhaps a provision can be made for this in the settings? This is just a quick fix to a problem that has been bothering me. I expected that when I selected "don't suspend pinned tabs" in settings, that it would also apply when I press "suspend others" or "suspend all".