### PR TITLE
Add support for a "close all suspended tabs" option

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -63,7 +63,7 @@ a {
 .group {
 	padding: 5px 0;
 }
-.optsCurrent, .optsAll, .optsSelected {
+.optsCurrent, .optsAll, .optsSelected, .optsCloseAll {
 	border-bottom: 1px solid #ccc;
 }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -285,6 +285,28 @@ var tgs = (function () {
         });
     }
 
+    function closeAllSuspendedTabs() {
+        chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+            var curWindowId = tabs[0].windowId;
+            chrome.windows.get(curWindowId, {populate: true}, function(curWindow) {
+                curWindow.tabs.forEach(function (tab) {
+                    if (isSuspended(tab)) {
+                        chrome.tabs.remove(tab.id);
+                    }
+                });
+            });
+        });
+    }
+
+    function closeSuspendedTabsInAllWindows() {
+        chrome.tabs.query({}, function (tabs) {
+            tabs.forEach(function (currentTab) {
+                if (isSuspended(tab))
+                    chrome.tabs.remove(tab.id);
+            });
+        });
+    }
+
     function isSuspended(tab) {
         return tab.url.indexOf('suspended.html') >= 0;
     }
@@ -866,6 +888,13 @@ var tgs = (function () {
                 onclick: unsuspendAllTabs
             }));
 
+            //Close all suspended tabs
+            contextMenuItems.push(chrome.contextMenus.create({
+                title: "Close All Suspended Tabs",
+                contexts: allContexts,
+                onclick: closeAllSuspendedTabs()
+            }));
+
              //Open settings page
             contextMenuItems.push(chrome.contextMenus.create({
                 title: "Settings",
@@ -900,6 +929,10 @@ var tgs = (function () {
 
         } else if (command === '6-unsuspend-all-windows') {
             unsuspendAllTabsInAllWindows();
+        } else if (command === '7-close-all-suspended-tabs') {
+	    closeAllSuspendedTabs();
+        } else if (command === '8-close-all-suspended-windows') {
+	    closeSuspendedTabsInAllWindows();
         }
     });
 
@@ -999,6 +1032,10 @@ var tgs = (function () {
 
         case 'unsuspendSelected':
             unsuspendSelectedTabs();
+            break;
+
+        case 'closeAllSuspended':
+            closeAllSuspendedTabs();
             break;
 
         default:

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -146,6 +146,10 @@
             });
             window.close();
         });
+        document.getElementById('closeAllSuspended').addEventListener('click', function (e) {
+            chrome.runtime.sendMessage({ action: 'closeAllSuspended' });
+            window.close();
+        });
 
         chrome.extension.getBackgroundPage().tgs.requestTabInfo(false, function (info) {
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -60,6 +60,12 @@
     },
     "6-unsuspend-all-windows": {
       "description": "Unsuspend all tabs in all windows"
+    },
+    "7-close-all-suspended-tabs": {
+      "description": "Close all suspended tabs in active window"
+    },
+    "8-close-all-suspended-windows": {
+      "description": "Close all suspended tabs in all windows"
     }
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -42,6 +42,12 @@
 		</div>
 	</div>
 
+	<div class="group optsCloseAll">
+		<div class="menuOption" id="closeAllSuspended">
+			<i class="fa fa-trash"></i> <span class="optionText">Close all suspended tabs</span>
+		</div>
+	</div>
+
 	<div class="group optsSettings">
 		<div class="menuOption" id="settingsLink">
 			<i class="fa fa-wrench"></i> <span class="optionText">Settings</span>


### PR DESCRIPTION
This option allows the user to close all suspended tabs.

As a user, I often end up with many suspended tabs with a few
unsuspended tabs mixed in.  This option has saved me a bunch of
headache having to search for all of the active tabs when I want
to clean up the old unused tabs.