### PR TITLE
Fix "Shoutouts" links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ This work is licensed under a GNU GENERAL PUBLIC LICENSE (v2)
 
 ### Shoutouts
 
-This package uses the [html2canvas] (https://github.com/niklasvh/html2canvas) library written by Niklas von Hertzen.  
-It also uses the indexedDb wrapper [db.js] (https://github.com/aaronpowell/db.js) written by Aaron Powell.  
-Thank you also to www.browserstack.com for providing free chrome testing tools.  
+This package uses the [html2canvas](https://github.com/niklasvh/html2canvas) library written by Niklas von Hertzen.  
+It also uses the indexedDb wrapper [db.js](https://github.com/aaronpowell/db.js) written by Aaron Powell.  
+Thank you also to [BrowserStack](https://www.browserstack.com) for providing free chrome testing tools.  


### PR DESCRIPTION
html2canvas and db.js weren't linked correctly, BrowserStack was only linked by URL.