### PR TITLE
Don't suspend tabs in active window

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -65,6 +65,7 @@
     "html_options_suspend_no_audio": { "message": "Never suspend tabs that are playing audio" },
     "html_options_suspend_only_connected": { "message": "Never suspend tabs when offline" },
     "html_options_suspend_only_on_battery": { "message": "Never suspend tabs when connected to power source" },
+    "html_options_suspend_no_tabs_in_active_window": { "message": "Never suspend tabs in the active window" },
     "html_options_suspend_no_active_tabs": { "message": "Never suspend active tab in each window" },
     "html_options_suspend_automatically_unsuspend": { "message": "Automatically unsuspend tab when it is viewed" },
     "html_options_suspend_theme": { "message": "Theme" },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -852,6 +852,10 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         });
     }
 
+    function getActiveWindowId() {
+        return _lastFocusedWindowId;
+    }
+
     //change the icon to either active or inactive
     function setIconStatus(status, tabId) {
         // gsUtils.log(tabId, 'Setting icon status: ' + status);
@@ -1146,6 +1150,7 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         buildContextMenu: buildContextMenu,
         resuspendSuspendedTab: resuspendSuspendedTab,
         getActiveTabStatus: getActiveTabStatus,
+        getActiveWindowId: getActiveWindowId,
         getDebugInfo: getDebugInfo,
         calculateTabStatus: calculateTabStatus,
         isCharging: isCharging,

--- a/src/js/gsStorage.js
+++ b/src/js/gsStorage.js
@@ -14,6 +14,7 @@ var gsStorage = {
     IGNORE_FORMS: 'gsDontSuspendForms',
     IGNORE_AUDIO: 'gsDontSuspendAudio',
     IGNORE_ACTIVE_TABS: 'gsDontSuspendActiveTabs',
+    IGNORE_ACTIVE_WINDOW_TABS: 'gsDontSuspendTabsInActiveWindow', 
     IGNORE_CACHE: 'gsIgnoreCache',
     ADD_CONTEXT: 'gsAddContextMenu',
     SYNC_SETTINGS: 'gsSyncSettings',
@@ -58,6 +59,7 @@ var gsStorage = {
         defaults[this.IGNORE_FORMS] = true;
         defaults[this.IGNORE_AUDIO] = true;
         defaults[this.IGNORE_ACTIVE_TABS] = true;
+        defaults[this.IGNORE_ACTIVE_WINDOW_TABS] = false;
         defaults[this.IGNORE_CACHE] = false;
         defaults[this.ADD_CONTEXT] = true;
         defaults[this.SYNC_SETTINGS] = true;

--- a/src/js/gsSuspendManager.js
+++ b/src/js/gsSuspendManager.js
@@ -172,7 +172,7 @@ var gsSuspendManager = (function () { // eslint-disable-line no-unused-vars
 
     // forceLevel indicates which users preferences to respect when attempting to suspend the tab
     // 1: Suspend if at all possible
-    // 2: Respect whitelist, temporary whitelist, form input, pinned tabs, audible preferences, and exclude current active tab
+    // 2: Respect whitelist, temporary whitelist, form input, pinned tabs, audible preferences, exclude current active window's tabs, and exclude current active tab
     // 3: Same as above (2), plus also respect internet connectivity and running on battery preferences.
     function checkTabEligibilityForSuspension(tab, forceLevel) {
         if (forceLevel >= 1) {
@@ -181,7 +181,7 @@ var gsSuspendManager = (function () { // eslint-disable-line no-unused-vars
             }
         }
         if (forceLevel >= 2) {
-            if (gsUtils.isProtectedActiveTab(tab) || gsUtils.checkWhiteList(tab.url) || gsUtils.isProtectedPinnedTab(tab) || gsUtils.isProtectedAudibleTab(tab)) {
+            if (gsUtils.isProtectedActiveTab(tab) || gsUtils.checkWhiteList(tab.url) || gsUtils.isProtectedPinnedTab(tab) || gsUtils.isProtectedAudibleTab(tab) || gsUtils.isProtectedTabInActiveWindow(tab)) {
                 return false;
             }
         }

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -111,6 +111,11 @@ var gsUtils = { // eslint-disable-line no-unused-vars
         return tgs.isCurrentFocusedTab(tab) || (dontSuspendActiveTabs && tab.active);
     },
 
+    isProtectedTabInActiveWindow: function (tab) {
+        var dontSuspendTabsInActiveWindow = gsStorage.getOption(gsStorage.IGNORE_ACTIVE_WINDOW_TABS)
+        return dontSuspendTabsInActiveWindow && tab.windowId === tgs.getActiveWindowId()
+    },
+
     isNormalTab: function (tab) {
         return !gsUtils.isSpecialTab(tab) && !gsUtils.isSuspendedTab(tab);
     },

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -16,6 +16,7 @@
         'dontSuspendForms': gsStorage.IGNORE_FORMS,
         'dontSuspendAudio': gsStorage.IGNORE_AUDIO,
         'dontSuspendActiveTabs': gsStorage.IGNORE_ACTIVE_TABS,
+        'dontSuspendTabsInActiveWindow': gsStorage.IGNORE_ACTIVE_WINDOW_TABS,
         'ignoreCache': gsStorage.IGNORE_CACHE,
         'addContextMenu': gsStorage.ADD_CONTEXT,
         'syncSettings': gsStorage.SYNC_SETTINGS,

--- a/src/options.html
+++ b/src/options.html
@@ -73,6 +73,10 @@
 					<label for="dontSuspendActiveTabs" class="cbLabel" data-i18n="__MSG_html_options_suspend_no_active_tabs__"></label>
 				</div>
 				<div class="formRow autoSuspendOption">
+					<input type="checkbox" id="dontSuspendTabsInActiveWindow" class='option' />
+					<label for="dontSuspendTabsInActiveWindow" class="cbLabel" data-i18n="__MSG_html_options_suspend_no_tabs_in_active_window__"></label>
+				</div>
+				<div class="formRow autoSuspendOption">
 					<input type="checkbox" id="onlineCheck" class='option' />
 					<label for="onlineCheck" class="cbLabel" data-i18n="__MSG_html_options_suspend_only_connected__"></label>
 				</div>


### PR DESCRIPTION
Someone on the r/chrome subreddit submitted [a post](https://www.reddit.com/r/chrome/comments/8gpp7n/chrome_extention_idea/) wanted to see if they could get an extension or an update to the great suspender that doesn't suspend tabs in the active window.

This PR includes an option to never suspend tabs in the active window. I'm sure some code could be optimized and not require a function to be added to the `tgs` object but ¯\\\_(ツ)\_/¯

Let me know if I need to change anything to fit the coding styles of the repo or what not.