### PR TITLE
Add support for resource (file://) URLs

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -222,6 +222,7 @@
     "js_popup_never": { "message": "Automatic tab suspension disabled." },
     "js_popup_no_connectivity": { "message": "No network connection" },
     "js_popup_charging": { "message": "Connected to power source" },
+    "js_popup_blockedFile": { "message": "Click to enable file access" },
     "js_popup_unknown": { "message": "Waiting for tab to load..." },
     "js_popup_initialising": { "message": "Waiting for extension to initialize..." },
     "js_popup_error": { "message": "Auto-suspend unavailable for this tab" },

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -53,6 +53,9 @@ a {
 #header.willSuspend {
   background: #3477db;
 }
+#header.blockedFile {
+    background: #a70707;
+}
 
 .group {
   padding: 10px 0;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -30,7 +30,8 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         _isCharging = false,
         _triggerHotkeyUpdate = false,
         _suspendUnsuspendHotkey,
-        _tabFlagsByTabId = {};
+        _tabFlagsByTabId = {},
+        _fileUrlsAccessAllowed;
 
     function init() {
 
@@ -652,6 +653,15 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         }
     }
 
+    function promptForFilePermissions() {
+        var proceed = confirm('The Great Suspender requires access to file URLs in order to suspend URLs beginning with "file://".\nPlease turn on "Allow access to file URLs" on the next page in order to enable suspension of file URLs.');
+        if (proceed) {
+            getCurrentlyActiveTab(function (activeTab) {
+                chrome.tabs.create({url: 'chrome://extensions?id=' + chrome.runtime.id, index: activeTab.index + 1});
+            });
+        }
+    }
+
     function checkForNotices() {
 
         var xhr = new XMLHttpRequest();
@@ -758,6 +768,7 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
     //loading: tab object has a state of 'loading'
     //normal: a tab that will be suspended
     //special: a tab that cannot be suspended
+    //blockedFile: a file:// tab that can theoretically be suspended but is being blocked by the user's settings
     //suspended: a tab that is suspended
     //discarded: a tab that has been discarded
     //never: suspension timer set to 'never suspend'
@@ -779,6 +790,11 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         //check if it is a special tab
         if (gsUtils.isSpecialTab(tab)) {
             callback('special');
+            return;
+        }
+        //check if it is a blockedFile tab
+        if (gsUtils.isBlockedFileTab(tab)) {
+            callback('blockedFile');
             return;
         }
         //check if tab has been discarded
@@ -1166,6 +1182,7 @@ var tgs = (function () { // eslint-disable-line no-unused-vars
         whitelistHighlightedTab: whitelistHighlightedTab,
         temporarilyWhitelistHighlightedTab: temporarilyWhitelistHighlightedTab,
         unsuspendAllTabsInAllWindows: unsuspendAllTabsInAllWindows,
+        promptForFilePermissions: promptForFilePermissions,
     };
 
 }());

--- a/src/js/gsSession.js
+++ b/src/js/gsSession.js
@@ -81,6 +81,12 @@ var gsSession = (function () { // eslint-disable-line no-unused-vars
     function runStartupChecks() {
         backgroundScriptsReadyAsPromsied().then(function () {
             initialisationMode = true;
+
+            // Check if the extension can work on file:// URLs
+            chrome.extension.isAllowedFileSchemeAccess(function(isAllowedAccess) {
+                tgs._fileUrlsAccessAllowed = isAllowedAccess;
+            });
+
             chrome.tabs.query({}, function (tabs) {
                 checkForBrowserStartup(tabs);
 

--- a/src/js/gsUtils.js
+++ b/src/js/gsUtils.js
@@ -83,8 +83,16 @@ var gsUtils = { // eslint-disable-line no-unused-vars
         // Careful, suspended urls start with "chrome-extension://"
         if (url.indexOf('about') === 0 ||
             url.indexOf('chrome') === 0 ||
-            url.indexOf('file') === 0 ||
             url.indexOf('chrome.google.com/webstore') >= 0) {
+            return true;
+        }
+        return false;
+    },
+
+    //tests if the page is a file:// page AND the user has not enabled access to
+    //file URLs in extension settings
+    isBlockedFileTab: function(tab) {
+        if (tab.url.indexOf('file') === 0 && !tgs._fileUrlsAccessAllowed) {
             return true;
         }
         return false;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -67,8 +67,8 @@
 
     function setSuspendCurrentVisibility(tabStatus) {
 
-        var suspendOneVisible = !['suspended', 'special', 'loading', 'unknown'].includes(tabStatus),
-            whitelistVisible = !['whitelisted', 'special', 'loading', 'unknown'].includes(tabStatus),
+        var suspendOneVisible = !['suspended', 'special', 'blockedFile', 'loading', 'unknown'].includes(tabStatus),
+            whitelistVisible = !['whitelisted', 'special', 'blockedFile', 'loading', 'unknown'].includes(tabStatus),
             pauseVisible = ['normal', 'audible', 'noConnectivity', 'charging', 'active'].includes(tabStatus);
 
         if (suspendOneVisible) {
@@ -157,6 +157,10 @@
             statusDetail = chrome.i18n.getMessage('js_popup_charging');
         //    statusIconClass = 'fa fa-plug';
 
+    } else if (status === 'blockedFile') {
+            statusDetail = '<a href="#">' + chrome.i18n.getMessage('js_popup_blockedFile') + '</a>';
+        //    statusIconClass = 'fa fa-exclamation-triangle';
+
         } else if (status === 'loading' || status === 'unknown') {
             if (gsSession.isInitialising()) {
                 statusDetail = chrome.i18n.getMessage('js_popup_initialising');
@@ -182,6 +186,9 @@
         if (status === 'normal' || status === 'active') {
             document.getElementById('header').classList.add('willSuspend');
         }
+        if (status === 'blockedFile') {
+            document.getElementById('header').classList.add('blockedFile');
+        }
 
         // Update action handler
         var actionEl = document.getElementsByTagName('a')[0];
@@ -196,6 +203,8 @@
 
             } else if (status === 'formInput' || status === 'tempWhitelist') {
                 tgsHanderFunc = tgs.undoTemporarilyWhitelistHighlightedTab;
+            } else if (status === 'blockedFile') {
+                tgsHanderFunc = tgs.promptForFilePermissions;
             }
 
             if (globalActionElListener) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
     "unlimitedStorage",
     "http://*/*",
     "https://*/*",
+    "file://*/*",
     "chrome://favicon/*",
     "https://greatsuspender.github.io/",
     "contextMenus",
@@ -22,7 +23,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
+      "matches": ["http://*/*", "https://*/*", "file://*/*"],
       "js": ["js/contentscript.js"]
     }
   ],


### PR DESCRIPTION
This is in response to issue #62.

- I created a new type of tab, a blockedFile tab, that is somewhere between normal and special, because it can theoretically be suspended but the user has to change their settings for the extension to be able to suspend it. If the file url setting is enabled then file tabs just show up as normal tabs that can be suspended.
- Adding `file://*/*` to the permissions and content_scripts allows the tab to be suspended and unsuspended without any issues.
- The prompt for file permissions is a regular JS confirm dialog. I feel like it could be more elegant but I didn't want to make any large additions to the popup without confirming first.
- I hid whitelisting options for file urls, since if people want to whitelist an entire protocol they can do that using RegEx like they would for http or https (plus clicking it on a file url doesn't work, and sometime breaks the extension until you edit the whitelist manually).
- The extension only checks the fille url access setting when it starts, as changing that setting restarts the extension.
- Changing the setting while you have suspended tabs closes them (since the extension restarts), but the session manager popped up fine for me and offered to restore my tabs. I don't know if there should be a warning for users in the popup.
- Lastly, I don't really know JavaScript, so if I used callbacks wrong or implemented my code backwards or bad programming practice just let me know.

(And personal opinion, I prefer the old suspender guy, he had more character.)