### PR TITLE
Fix for #750

### DIFF
--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -168,16 +168,14 @@ body.img-preview-mode .gsTopBar {
 .suspendedMsg-snoozy {
     position: relative;
     flex: 1 1 100%;
-    max-height: 180px;
+    max-height: 210px;
     min-height: 80px;
-    width: 100%;
+    width: 180px;
     padding-bottom: 30px;
 }
 .suspendedMsg-snoozy img {
     height: 100%;
-}
-.suspendedTextWrap {
-    flex-shrink: 0;
+    max-height: 180px;
 }
 .suspendedMsg-instr {
     font-size: 20px;

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -89,7 +89,7 @@ body.suspended-page:not(.img-preview-mode) {
     padding: 30px 40px 20px;
     width: 100%;
     text-align: center;
-    z-index: 10;
+    z-index: 101;
 }
 .faviconWrap {
     display: inline-block;
@@ -163,19 +163,10 @@ body.img-preview-mode .gsTopBar {
     justify-content: center;
     flex-direction: column;
     text-align: center;
-    padding: 130px 0;
 }
-.suspendedMsg-snoozy {
-    position: relative;
-    flex: 1 1 100%;
-    max-height: 210px;
-    min-height: 80px;
-    width: 180px;
-    padding-bottom: 30px;
-}
-.suspendedMsg-snoozy img {
-    height: 100%;
-    max-height: 180px;
+.suspendedMsg img {
+    height: 180px;
+    margin-bottom: 30px;
 }
 .suspendedMsg-instr {
     font-size: 20px;

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -89,6 +89,7 @@ body.suspended-page:not(.img-preview-mode) {
     padding: 30px 40px 20px;
     width: 100%;
     text-align: center;
+    z-index: 10;
 }
 .faviconWrap {
     display: inline-block;
@@ -162,10 +163,21 @@ body.img-preview-mode .gsTopBar {
     justify-content: center;
     flex-direction: column;
     text-align: center;
+    padding-top: 130px;
 }
-.suspendedMsg img {
-    height: 180px;
-    margin-bottom: 30px;
+.suspendedMsg-snoozy {
+    position: relative;
+    flex: 1 1 100%;
+    max-height: 180px;
+    min-height: 80px;
+    width: 100%;
+    padding-bottom: 30px;
+}
+.suspendedMsg-snoozy img {
+    height: 100%;
+}
+.suspendedTextWrap {
+    flex-shrink: 0;
 }
 .suspendedMsg-instr {
     font-size: 20px;

--- a/src/css/suspended.css
+++ b/src/css/suspended.css
@@ -163,7 +163,7 @@ body.img-preview-mode .gsTopBar {
     justify-content: center;
     flex-direction: column;
     text-align: center;
-    padding-top: 130px;
+    padding: 130px 0;
 }
 .suspendedMsg-snoozy {
     position: relative;

--- a/src/suspended.html
+++ b/src/suspended.html
@@ -46,7 +46,7 @@
 	</div>
 
 	<div id="suspendedMsg" class="suspendedMsg">
-		<div class="suspendedMsg-snoozy">
+		<div style="position: relative">
 			<img id="snoozyImg" src="img/snoozy_tab.svg" />
 			<div id="snoozySpinner"></div>
 		</div>

--- a/src/suspended.html
+++ b/src/suspended.html
@@ -46,7 +46,7 @@
 	</div>
 
 	<div id="suspendedMsg" class="suspendedMsg">
-		<div style="position: relative">
+		<div class="suspendedMsg-snoozy">
 			<img id="snoozyImg" src="img/snoozy_tab.svg" />
 			<div id="snoozySpinner"></div>
 		</div>


### PR DESCRIPTION
This shrinks the Snoozy image when the window gets below a certain height. 

![image](https://user-images.githubusercontent.com/61631/45125682-771b0a80-b124-11e8-9e72-640730c366e5.png)

At smaller heights, it will be clipped the top bar:

![image](https://user-images.githubusercontent.com/61631/45125712-97e36000-b124-11e8-8b02-f31db6397471.png)

The spinner is currently in the wrong place when Snoozy starts shrinking.  That should be fixable, but wanted to check first if this seems like a useful fix before tackling that.