### PR TITLE
Stops translation prompt on suspended pages. 

### DIFF
--- a/src/suspended.html
+++ b/src/suspended.html
@@ -7,6 +7,7 @@
 	<link rel="stylesheet" type="text/css" href="css/suspended.css">
 	<script type="text/javascript" src="js/suspended.js"></script>
 	<title id="gsTitle" data-i18n="__MSG_html_suspended_title__"></title>
+	<meta name="google" content="notranslate">
 </head>
 
 <body class="suspended-page hide-initially">


### PR DESCRIPTION
We handle translations for some specific languages, and we don't have enough content to warrant google translating the page.

Stops this from intermittently happening:
![screen shot 2018-10-23 at 12 50 02 pm](https://user-images.githubusercontent.com/1134713/47326108-b21cd180-d6c3-11e8-8864-17efe915356e.png)
