### PR TITLE
Fix for #821,822,823

### DIFF
--- a/src/js/gsFavicon.js
+++ b/src/js/gsFavicon.js
@@ -286,7 +286,12 @@ var gsFavicon = (function() {
     const timeout = 5 * 1000;
     return new Promise((resolve, reject) => {
       const img = new Image();
-      let imageLoaded = false;
+      // 12-16-2018 ::: @CollinChaffin ::: Anonymous declaration required to prevent terminating cross origin security errors
+	  // 12-16-2018 ::: @CollinChaffin ::: http://bit.ly/2BolEqx
+	  // 12-16-2018 ::: @CollinChaffin ::: https://bugs.chromium.org/p/chromium/issues/detail?id=409090#c23
+	  // 12-16-2018 ::: @CollinChaffin ::: https://bugs.chromium.org/p/chromium/issues/detail?id=718352#c10	  
+	  img.crossOrigin = "Anonymous";
+	  let imageLoaded = false;
 
       img.onload = async function() {
         imageLoaded = true;


### PR DESCRIPTION
Cross origin security blocking prevents TGS from initializing when it cannot complete favIcon operations.  This requires Anonymous declaration of crossOrigin.

More info:
https://stackoverflow.com/questions/49503171/the-image-tag-with-crossorigin-anonymous-cant-load-success-from-s3
https://bugs.chromium.org/p/chromium/issues/detail?id=409090#c23
https://bugs.chromium.org/p/chromium/issues/detail?id=718352#c10

TODO: Consider (continued) refactoring of favIcon (and other critical component) error handling/logging particularily during TGS startup/init