### PR TITLE
Fix for space being applied to link text instead of just the shortcut text

### DIFF
--- a/src/js/gsSuspendedTab.js
+++ b/src/js/gsSuspendedTab.js
@@ -330,9 +330,9 @@ var gsSuspendedTab = (function() {
   }
 
   function setCommand(_document, command) {
-    const hotkeyEl = _document.getElementById('hotkeyCommand');
+    const hotkeyEl = _document.getElementById('hotkeyWrapper');
     if (command) {
-      hotkeyEl.innerHTML = '(' + command + ')';
+      hotkeyEl.innerHTML = '<span class="hotkeyCommand">(' + command + ')</a>';
     } else {
       const reloadString = chrome.i18n.getMessage(
         'js_suspended_hotkey_to_reload'

--- a/src/suspended.html
+++ b/src/suspended.html
@@ -55,7 +55,7 @@
 				<div data-i18n="__MSG_html_suspended_click_to_reload__"></div>
 			</div>
 			<div class="suspendedMsg-shortcut">
-				<span id="hotkeyCommand" class="hotkeyCommand"></span>
+				<span id="hotkeyWrapper" class="hotkeyWrapper"></span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
<img width="280" alt="screen shot 2019-01-08 at 10 59 07 am" src="https://user-images.githubusercontent.com/1134713/50796674-36800780-1337-11e9-8e52-a4278aeb2c35.png">
