### PR TITLE
Make suspended tab render better on small resolutions

### DIFF
--- a/src/suspended.html
+++ b/src/suspended.html
@@ -3,6 +3,7 @@
 
 <head>
 	<!--should use the same as the default extension favicon-->
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link id="gsFavicon" rel="icon" href="img/ic_suspendy_16x16.png" />
 	<link rel="stylesheet" type="text/css" href="css/suspended.css">
 	<title id="gsTitle" data-i18n="__MSG_html_suspended_title__"></title>


### PR DESCRIPTION
TGS is desktop-focussed, but handy for web devs (like me) who have tabs open in device-mode. 

Should be handy if this ever does get used on mobile.

Changes this:
<img width="690" alt="screen shot 2019-01-08 at 11 24 42 am" src="https://user-images.githubusercontent.com/1134713/50797410-9081cc80-1339-11e9-9c30-da7cf18f737d.png">


To this:
<img width="681" alt="screen shot 2019-01-08 at 11 31 52 am" src="https://user-images.githubusercontent.com/1134713/50797421-97a8da80-1339-11e9-9b57-57a90e15d73f.png">

Tested and working with screenshot mode turned on :)