### PR TITLE
Restoring-window view and automatic save points russian translation

### DIFF
--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -136,7 +136,7 @@
     "html_popup_settings": { "message": "Настройки" },
     "html_restoring_title": { "message": "Восстановление окна" },
     "html_restoring_heading": { "message": "Восстановление вкладок" },
-    "html_restoring_detail": { "message": "Пожалуйста, подождите пока я восстановлю это окно..." },
+    "html_restoring_detail": { "message": "Пожалуйста, подождите, пока я восстановлю это окно..." },
     "html_recovery_title": { "message": "Восстановление" },
     "html_recovery_ruh_roh": { "message": "Ой-ой!" },
     "html_recovery_description_line1": { "message": "Кажется, расширение завершило работу некорректно." },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -134,9 +134,9 @@
     "html_popup_suspend_selected_tabs": { "message": "Приостановить выбранные вкладки" },
     "html_popup_unsuspend_selected_tabs": { "message": "Возобновить выбранные вкладки" },
     "html_popup_settings": { "message": "Настройки" },
-    "html_restoring_title": { "message": "Restoring window" },
-    "html_restoring_heading": { "message": "Restoring tabs" },
-    "html_restoring_detail": { "message": "Please wait while I restore this window..." },
+    "html_restoring_title": { "message": "Восстановление окна" },
+    "html_restoring_heading": { "message": "Восстановление вкладок" },
+    "html_restoring_detail": { "message": "Пожалуйста, подождите пока я восстановлю это окно..." },
     "html_recovery_title": { "message": "Восстановление" },
     "html_recovery_ruh_roh": { "message": "Ой-ой!" },
     "html_recovery_description_line1": { "message": "Кажется, расширение завершило работу некорректно." },
@@ -235,8 +235,8 @@
     "js_history_reload": { "message": "обновить" },
     "js_history_resuspend": { "message": "приостановить" },
     "js_history_save": { "message": "сохранить" },
-    "js_history_window": { "message": "окно" },
-    "js_history_tab": { "message": "вкладка" },
+    "js_history_window": { "message": "Окно" },
+    "js_history_tab": { "message": "Вкладка" },
     "js_history_plural": { "message": "" },
     "js_history_enter_name_for_session": { "message": "Введите имя для сессии" },
     "js_history_confirm_delete": { "message": "Вы точно хотите удалить сессию?" },
@@ -252,5 +252,5 @@
     "js_update_button_export": { "message": "Сохранить резервную копию" },
     "js_update_button_reload": { "message": "Обновить расширение" },
     "js_shortcuts_not_set": { "message": "не задано" },
-    "js_session_save_point": { "message": "Автоматическая точка сохранения для " }
+    "js_session_save_point": { "message": "Автоматическая точка восстановления для версии " }
 }


### PR DESCRIPTION
Made "js_history_window" and "js_history_tab" to start with capital letter according with latest English changes [here](https://github.com/deanoemcke/thegreatsuspender/commit/b7157c38db080fceca29e20378022c007ddaf765), in "js_session_save_point" used russian word restore by analogy with Windows automatic restore points but original is ok too, waiting on ur opinions.