### PR TITLE
Implemented preview of tab names that match programmed patterns in WHITELIST

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -146,6 +146,17 @@
         if (getOptionValue(element)) {
           setSyncNoteVisibility(false);
         }
+      } else if (pref === gsStorage.WHITELIST) {
+        chrome.tabs.query({}, function(tabs) {
+          var matches = [];
+          var newWhitelist = getOptionValue(element);
+          tabs.forEach(function(tab) {
+            if (gsUtils.checkSpecificWhiteList(tab.url, newWhitelist)) {
+              matches.push(tab.title);
+            }
+          });
+          document.getElementById("whitelist_matches").innerText = matches.join("\n ");
+        });
       }
 
       var [oldValue, newValue] = saveChange(element);

--- a/src/options.html
+++ b/src/options.html
@@ -113,6 +113,7 @@ __MSG_html_options_whitelist_tooltip_line3__
 						<i class="tooltipIcon icon icon-help-circled"></i>
 					</span>
 					<textarea id="whitelist" class="option" rows="10" cols="50"></textarea>
+					<span id="whitelist_matches"></span>
 				</div>
 			</div>
 			<div class="sub-section">


### PR DESCRIPTION
In particular, when trying to create regex with the great suspender that match various tab names I encountered a great deal of difficulty testing if my regex were actually working.

I implemented a mockup of what a preview of 'matching tabs' which would be whitelisted based on the tabs that are currently open in the user's browser would look like. At the moment I simply show the page title's.

For example, in my case I added a simple rule to just exclude any pdf's from being excluded (with a few pdf's already open in my browser)
![image](https://user-images.githubusercontent.com/7906572/54394552-6ff02e80-466a-11e9-9f85-1fb63a6a3a44.png)

Note: this is more of a feature request/example implementation than necessarily a final product to be merged.