### PR TITLE
System theme mode support

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -84,6 +84,7 @@
     "html_options_suspend_discard_after_suspend_tooltip_line3a": { "message": "For more information on Chrome discarding refer to:" },
     "html_options_suspend_discard_after_suspend_tooltip_line3b": { "message": "https://developers.google.com/web/updates/2015/09/tab-discarding" },
     "html_options_suspend_theme": { "message": "Theme" },
+    "html_options_suspend_theme_system": { "message": "Use system setting" },
     "html_options_suspend_theme_light": { "message": "Light" },
     "html_options_suspend_theme_dark": { "message": "Dark" },
     "html_options_suspend_screen_capturing": { "message": "Screen capturing" },

--- a/src/js/gsSuspendedTab.js
+++ b/src/js/gsSuspendedTab.js
@@ -182,13 +182,13 @@ var gsSuspendedTab = (function() {
   }
 
   function setTheme(_document, theme, isLowContrastFavicon) {
-    if (theme === 'dark') {
+    if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       _document.querySelector('body').classList.add('dark');
     } else {
       _document.querySelector('body').classList.remove('dark');
     }
 
-    if (theme === 'dark' && isLowContrastFavicon) {
+    if ((theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) && isLowContrastFavicon) {
       _document
         .getElementById('faviconWrap')
         .classList.add('faviconWrapLowContrast');

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -258,7 +258,7 @@
 
   function showPopupContents() {
     const theme = gsStorage.getOption(gsStorage.THEME);
-    if (theme === 'dark') {
+    if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       document.body.classList.add('dark');
     }
     setTimeout(function() {

--- a/src/options.html
+++ b/src/options.html
@@ -145,6 +145,7 @@ __MSG_html_options_suspend_discard_after_suspend_tooltip_line3b__">
 					<br />
 					<div class="select-wrapper">
 						<select id="theme" class='option'>
+							<option value="system" data-i18n="__MSG_html_options_suspend_theme_system__"></option>
 							<option value="light" data-i18n="__MSG_html_options_suspend_theme_light__"></option>
 							<option value="dark" data-i18n="__MSG_html_options_suspend_theme_dark__"></option>
 						</select>


### PR DESCRIPTION
This PR looks at the user's system-wide theme setting. If the user has their setting as the new TGS theme option 'system', and their system-wide preference is dark, then it applies the dark styling to the suspended page and popup.

Note this is not currently working for some reason.... need to figure out why. I'm trying to do it with JS, but even a basic CSS detection is not working for me
`@media (prefers-color-scheme: dark) {`
    `*  {color: red!important;}` // nothing happens
`}`