### PR TITLE
Fix dom-to-image: illegal symbols in data-uri, zero height svg

### DIFF
--- a/src/js/dom-to-image.js
+++ b/src/js/dom-to-image.js
@@ -1,6 +1,6 @@
 // dom-to-image-2.6.0
-// patched to add toCanvas public function (line 111)
-// patched to fix uncaught in promise (line 741)
+// patched to add toCanvas public function (line 112)
+// patched to fix uncaught in promise (line 742)
 // patched to fix illegal symbols in data-uri (line 349, 358)
 (function (global) {
     'use strict';

--- a/src/js/dom-to-image.js
+++ b/src/js/dom-to-image.js
@@ -1,6 +1,7 @@
 // dom-to-image-2.6.0
 // patched to add toCanvas public function (line 111)
 // patched to fix uncaught in promise (line 741)
+// patched to fix illegal symbols in data-uri (line 349, 358)
 (function (global) {
     'use strict';
 
@@ -345,7 +346,7 @@
                 node.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
                 return new XMLSerializer().serializeToString(node);
             })
-            .then(util.escapeXhtml)
+            // .then(util.escapeXhtml)
             .then(function (xhtml) {
                 return '<foreignObject x="0" y="0" width="100%" height="100%">' + xhtml + '</foreignObject>';
             })
@@ -354,7 +355,7 @@
                     foreignObject + '</svg>';
             })
             .then(function (svg) {
-                return 'data:image/svg+xml;charset=utf-8,' + svg;
+                return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
             });
     }
 

--- a/src/js/gsTabSuspendManager.js
+++ b/src/js/gsTabSuspendManager.js
@@ -560,7 +560,7 @@ var gsTabSuspendManager = (function() {
     if (useAlternateScreenCaptureLib) {
       // console.log('Generating via dom-to-image..');
       generateCanvas = () => {
-        return domtoimage.toCanvas(document.body, {}).then(canvas => {
+        return domtoimage.toCanvas(document.body, {width: width, height: height}).then(canvas => {
           const croppedCanvas = document.createElement('canvas');
           const context = croppedCanvas.getContext('2d');
           croppedCanvas.width = width;


### PR DESCRIPTION
## Illegal symbols in data-uri
I'm using dom-to-image as default webpage capturing lib. I noticed that TGS sometimes cannot capture screenshot of github issue pages such as [deanoemcke/thegreatsuspender/issues](https://github.com/deanoemcke/thegreatsuspender/issues).

I made some investigation and found this issue: https://github.com/tsayen/dom-to-image/issues/243. The problem is due to insufficient escaping of symbols in data-uri. Details are describe in https://github.com/tsayen/dom-to-image/issues/243#issuecomment-541667673.

## Zero height svg for websites like youtube
Websites like youbube have `document.body.scrollHeight == 0`, while dom-to-image itself does not try to use `document.documentElement.scrollHeight`. TGS has already considered `document.documentElement.scrollHeight`, but it didn't provide obtained height value to dom-to-image lib, where `height` is used in constructing svg document.